### PR TITLE
Animate inner HTML, not entire body

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -15,7 +15,7 @@ body.pg-loaded .inner {
   display: block;
 }
 
-body.pg-loaded {
+body.pg-loaded .inner {
   opacity: 1;
   -webkit-animation: pgAnimLoading 0.3s cubic-bezier(0.7, 0, 0.3, 1) both;
   -moz-animation: pgAnimLoading 0.3s cubic-bezier(0.7, 0, 0.3, 1) both;


### PR DESCRIPTION
This matters in an updated version of PleaseWait where pg-loaded is added to the body as soon as finish() is called.
By animating the entire body, the demo app ends up animating the loading screen too...
