### PR TITLE
Update please-wait.scss

### DIFF
--- a/src/please-wait.scss
+++ b/src/please-wait.scss
@@ -85,6 +85,8 @@ body.pg-loading {
 
     img {
       display: inline-block !important;
+      max-width: 100%;
+      height: auto;
     }
   }
 


### PR DESCRIPTION
logo images aren't responsive with small screens & mobiles  , these properties are exactly what in Bootstrap "img-responsive" class
![please wait bug](https://cloud.githubusercontent.com/assets/9960335/17830653/50bca9d4-66da-11e6-8881-e4a3acfb8802.PNG)
